### PR TITLE
Fix array test

### DIFF
--- a/test/04-arrays-tests.js
+++ b/test/04-arrays-tests.js
@@ -231,10 +231,10 @@ describe('04-arrays-tasks', function() {
                 expected: [ 'x', 1, 'b', 'c' ]
             }
         ].forEach(data => {
-            tasks.insertItem(data.arr, data.item, data.index);
+            var actual = tasks.insertItem(data.arr, data.item, data.index);
             assert.deepEqual(
                 data.expected,
-                data.arr
+                actual
             );
         });
     });


### PR DESCRIPTION
There is some mistake In test for task "Inserts the item into specified array at specified index" of array tasks. Test try to compare expected array and incoming (not returning) and here is a mistake.
Declare variable 'actual' so test goes well.
Cheers!