### PR TITLE
changed the accuracy of comparison with the result of method angleBet…

### DIFF
--- a/test/03-date-tests.js
+++ b/test/03-date-tests.js
@@ -126,8 +126,8 @@ describe('03-date-tasks', function() {
             }
         ].forEach(data => {
             assert.equal(
-                tasks.angleBetweenClockHands(new Date(data.date)),
-                data.expected,
+                tasks.angleBetweenClockHands(new Date(data.date)).toFixed(14),
+                data.expected.toFixed(14),
                 `Incorrect result for angleBetweenClockHands(${new Date(data.date).toUTCString()}):`   
             );
         });


### PR DESCRIPTION
…weenClockHands

В таске 03-date-tasks.js есть крайнее задание angleBetweenClockHands, в котором у меня не проходят тесты из-за ошибок округления на 16 знаках после запятой. Буквально, у меня `0.8726646259971647`, а тест хочет `0.8726646259971648`. 
Поэтому хорошо бы их округлять перед проверкой.