### PR TITLE
parseDataFromRfc2822 test fix

### DIFF
--- a/test/03-date-tests.js
+++ b/test/03-date-tests.js
@@ -19,7 +19,7 @@ describe('03-date-tasks', function() {
 
         assert.equal(
             895370400000,
-            tasks.parseDataFromRfc2822('Sun, 17 May 1998 03:00:00 GMT+01').valueOf()
+            tasks.parseDataFromRfc2822('Sun, 17 May 1998 03:00:00 GMT+0100').valueOf()
         );
     });
 


### PR DESCRIPTION
@dzmitry-varabei @aorgish  
It looks like GMT+01 is not valid for Rfc2822.
https://tools.ietf.org/html/rfc2822

... zone MUST be within the range -9959 through +9959....

3.3. Date and Time Specification
zone            =       (( "+" / "-" ) 4DIGIT) / obs-zone

So it should be 4digit in hhmm format. It is the reason why the test fails for some versions of v8 engines.
For example that doesn't work for nodejs 4.4.3. It looks like it is interpreted as minutes(mm)
https://www.screencast.com/t/l9mbjVX0uS4